### PR TITLE
Pass in connection to methods (e.g. Staff.list)

### DIFF
--- a/lib/xpm_ruby/staff.rb
+++ b/lib/xpm_ruby/staff.rb
@@ -12,10 +12,8 @@ module XpmRuby
       Models::Staff.new(args)
     end
 
-    def list(api_key:, account_key:, api_url:)
-      response = Connection
-        .new(api_key: api_key, account_key: account_key, api_url: api_url)
-        .get(endpoint: "staff.api/list")
+    def list(connection:)
+      response = connection.get(endpoint: "staff.api/list")
 
       case response.status
       when 401

--- a/spec/xpm_ruby/staff_spec.rb
+++ b/spec/xpm_ruby/staff_spec.rb
@@ -29,7 +29,8 @@ module XpmRuby
         end
 
         it "lists staff" do
-          staff_list = service.list(api_key: api_key, account_key: account_key, api_url: api_url)
+          connection = XpmRuby::Connection.new(api_key: api_key, account_key: account_key, api_url: api_url)
+          staff_list = service.list(connection: connection)
 
           staff = staff_list.last
 


### PR DESCRIPTION
If we pass in the connection to the Staff.list this means we only need to instantiate the connection once which might make it easier when instantiating multiple objects at once

e.g.

```
connection = XpmRuby::Connection.new(api_key: api_key, account_key: account_key, api_url: api_url)
staff_list = XpmRuby::Staff.list(connection: connection)
client_list = XpmRuby::Client.list(connection: connection)
etc...
```
