### PR TITLE
remove faraday version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     xpm_ruby (0.1.0)
-      faraday (~> 1)
+      faraday
       nokogiri
       ox (~> 2.13)
 

--- a/xpm_ruby.gemspec
+++ b/xpm_ruby.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("byebug", "~> 11")
   spec.add_development_dependency("pry-byebug", "~> 3")
 
-  spec.add_runtime_dependency("faraday", "~> 1")
+  spec.add_runtime_dependency("faraday")
   spec.add_runtime_dependency("nokogiri")
   spec.add_runtime_dependency("ox", "~> 2.13")
 


### PR DESCRIPTION
**Motivation (Why)**

Fix `bundle install` in main app

```
Resolving dependencies.......
Bundler could not find compatible versions for gem "faraday":
  In snapshot (Gemfile.lock):
    faraday (= 0.15.4)
  In Gemfile:
    chartmogul-ruby was resolved to 1.5.0, which depends on
      faraday (~> 0.15.0)
    xpm_ruby was resolved to 0.1.0, which depends on
      faraday (~> 1)
Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```