### PR TITLE
Add dry types to client (and also refactored dry types on job)

### DIFF
--- a/lib/xpm_ruby.rb
+++ b/lib/xpm_ruby.rb
@@ -10,7 +10,10 @@ require "builder"
 require "xpm_ruby/client"
 require "xpm_ruby/connection"
 require "xpm_ruby/job"
+
+require "xpm_ruby/schema/client/add"
 require "xpm_ruby/schema/job/add"
+
 require "xpm_ruby/staff"
 require "xpm_ruby/template"
 require "xpm_ruby/version"

--- a/lib/xpm_ruby/client.rb
+++ b/lib/xpm_ruby/client.rb
@@ -49,7 +49,7 @@ module XpmRuby
     end
 
     def add(access_token:, xero_tenant_id:, client:)
-      validated_client = XpmRuby::Schema::Client::Add[client]
+      validated_client = Schema::Client::Add[client]
 
       response = Connection
         .new(access_token: access_token, xero_tenant_id: xero_tenant_id)

--- a/lib/xpm_ruby/client.rb
+++ b/lib/xpm_ruby/client.rb
@@ -49,9 +49,11 @@ module XpmRuby
     end
 
     def add(access_token:, xero_tenant_id:, client:)
+      validated_client = XpmRuby::Schema::Client::Add[client]
+
       response = Connection
         .new(access_token: access_token, xero_tenant_id: xero_tenant_id)
-        .post(endpoint: "client.api/add", data: client.to_xml(root: "Client"))
+        .post(endpoint: "client.api/add", data: validated_client.to_xml(root: "Client"))
 
       response["Client"]
     end

--- a/lib/xpm_ruby/job.rb
+++ b/lib/xpm_ruby/job.rb
@@ -19,7 +19,7 @@ module XpmRuby
     end
 
     def add(access_token:, xero_tenant_id:, job:)
-      validated_job = XpmRuby::Schema::Job::Add[job]
+      validated_job = Schema::Job::Add[job]
 
       response = Connection
         .new(access_token: access_token, xero_tenant_id: xero_tenant_id)

--- a/lib/xpm_ruby/schema/client/add.rb
+++ b/lib/xpm_ruby/schema/client/add.rb
@@ -33,7 +33,7 @@ module XpmRuby
               Phone?: Types::Coercible::String,
               Mobile?: Types::Coercible::String,
               Email?: Types::String,
-              Position?: Types::String,
+              Position?: Types::String
             ).with_key_transform(&:to_sym)
           ).with_key_transform(&:to_sym)
         ),

--- a/lib/xpm_ruby/schema/client/add.rb
+++ b/lib/xpm_ruby/schema/client/add.rb
@@ -1,0 +1,66 @@
+require_relative "../../types"
+
+module XpmRuby
+  module Schema
+    module Client
+      Add = Types::Hash.schema(
+        Name: Types::String,
+        Email?: Types::String,
+        Address?: Types::String,
+        City?: Types::String,
+        Region?: Types::String,
+        PostCode?: Types::String,
+        Country?: Types::String,
+        PostalAddress?: Types::String,
+        PostalCity?: Types::String,
+        PostalRegion?: Types::String,
+        PostalPostCode?: Types::String,
+        PostalCountry?: Types::String,
+        Phone?: Types::Coercible::String,
+        Fax?: Types::Coercible::String,
+        WebSite?: Types::String,
+        ReferralSource?: Types::String,
+        ExportCode?: Types::String,
+        IsProspect?: Types::String,
+        AccountManagerID?: Types::String,
+        Contacts?: Types::Array.of(
+          Types::Hash.schema(
+            Contact: Types::Hash.schema(
+              Name: Types::String,
+              IsPrimary?: Types::String,
+              Salutation?: Types::String,
+              Addressee?: Types::String,
+              Phone?: Types::Coercible::String,
+              Mobile?: Types::Coercible::String,
+              Email?: Types::String,
+              Position?: Types::String,
+            ).with_key_transform(&:to_sym)
+          ).with_key_transform(&:to_sym)
+        ),
+        BillingClientID?: Types::Coercible::String,
+        FirstName?: Types::String,
+        LastName?: Types::String,
+        OtherName?: Types::String,
+        DateOfBirth?: Types::Coercible::String,
+        JobManagerID?: Types::Coercible::String,
+        TaxNumber?: Types::Coercible::String,
+        CompanyNumber?: Types::Coercible::String,
+        BusinessNumber?: Types::Coercible::String,
+        BusinessStructure?: Types::String,
+        BalanceMonth?: Types::Coercible::String,
+        PrepareGST?: Types::String,
+        GSTRegistered?: Types::String,
+        GSTPeriod?: Types::Coercible::String,
+        GSTBasis?: Types::String,
+        ProvisionalTaxBasis?: Types::String,
+        ProvisionalTaxRatio?: Types::String,
+        SignedTaxAuthority?: Types::String,
+        TaxAgent?: Types::String,
+        AgencyStatus?: Types::String,
+        ReturnType?: Types::String,
+        PrepareActivityStatement?: Types::String,
+        PrepareTaxReturn?: Types::String
+      ).with_key_transform(&:to_sym)
+    end
+  end
+end

--- a/lib/xpm_ruby/schema/job/add.rb
+++ b/lib/xpm_ruby/schema/job/add.rb
@@ -4,18 +4,18 @@ module XpmRuby
   module Schema
     module Job
       Add = Types::Hash.schema(
-        "Name" => Types::String,
-        "Description" => Types::String,
-        "ClientID" => Types::Coercible::String,
-        "ContactID?" => Types::Coercible::String,
-        "StartDate" => Types::Coercible::String,
-        "DueDate" => Types::Coercible::String,
-        "ClientNumber?" => Types::Coercible::String,
-        "ID?" => Types::Coercible::String,
-        "TemplateID?" => Types::Coercible::String,
-        "CategoryID?" => Types::Coercible::String,
-        "Budget?" => Types::Coercible::String
-      )
+        Name: Types::String,
+        Description: Types::String,
+        ClientID: Types::Coercible::String,
+        ContactID?: Types::Coercible::String,
+        StartDate: Types::Coercible::String,
+        DueDate: Types::Coercible::String,
+        ClientNumber?: Types::Coercible::String,
+        ID?: Types::Coercible::String,
+        TemplateID?: Types::Coercible::String,
+        CategoryID?: Types::Coercible::String,
+        Budget?: Types::Coercible::String
+      ).with_key_transform(&:to_sym)
     end
   end
 end

--- a/spec/xpm_ruby/schema/client/add_spec.rb
+++ b/spec/xpm_ruby/schema/client/add_spec.rb
@@ -7,20 +7,20 @@ module XpmRuby
         context "with contacts" do
           it "should not raise an error" do
             hash = { "Name" => "Joe Bloggs Consulting", "Contacts" => [{ "Contact" => { "Name" => "Joe Bloggs" } }] }
-            expect { XpmRuby::Schema::Client::Add[hash] }.not_to raise_error
+            expect { Client::Add[hash] }.not_to raise_error
           end
         end
 
         context "without contacts" do
           it "should not raise an error" do
             hash = { "Name" => "Joe Bloggs Consulting" }
-            expect { XpmRuby::Schema::Client::Add[hash] }.not_to raise_error
+            expect { Client::Add[hash] }.not_to raise_error
           end
         end
 
         it "should coerce the types" do
           hash = { "Name" => "Joe Bloggs", "Phone" => "88880000" }
-          add = XpmRuby::Schema::Client::Add[hash]
+          add = Client::Add[hash]
           expect(add[:Phone]).to eql("88880000")
         end
       end
@@ -28,12 +28,12 @@ module XpmRuby
       context "with an invalid Add schema" do
         it "should raise an error" do
           hash = { "Email" => "Joe Bloggs" }
-          expect { XpmRuby::Schema::Client::Add[hash] }.to raise_error(Dry::Types::ConstraintError, /Name is missing in Hash input/)
+          expect { Client::Add[hash] }.to raise_error(Dry::Types::ConstraintError, /Name is missing in Hash input/)
         end
 
         it "should raise an error on contacts" do
           hash = { "Name" => "Joe Bloggs Consulting", "Contacts" => [{ "Contact" => { "Email" => "Joe Bloggs" } }] }
-          expect { XpmRuby::Schema::Client::Add[hash] }.to raise_error(Dry::Types::ConstraintError, /Name is missing in Hash input/)
+          expect { Client::Add[hash] }.to raise_error(Dry::Types::ConstraintError, /Name is missing in Hash input/)
         end
       end
     end

--- a/spec/xpm_ruby/schema/client/add_spec.rb
+++ b/spec/xpm_ruby/schema/client/add_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+module XpmRuby
+  module Schema
+    RSpec.describe(Client) do
+      context "with a valid Add schema" do
+        context "with contacts" do
+          it "should not raise an error" do
+            hash = { "Name" => "Joe Bloggs Consulting", "Contacts" => [{ "Contact" => { "Name" => "Joe Bloggs" } }] }
+            expect { XpmRuby::Schema::Client::Add[hash] }.not_to raise_error
+          end
+        end
+
+        context "without contacts" do
+          it "should not raise an error" do
+            hash = { "Name" => "Joe Bloggs Consulting" }
+            expect { XpmRuby::Schema::Client::Add[hash] }.not_to raise_error
+          end
+        end
+
+        it "should coerce the types" do
+          hash = { "Name" => "Joe Bloggs", "Phone" => "88880000" }
+          add = XpmRuby::Schema::Client::Add[hash]
+          expect(add[:Phone]).to eql("88880000")
+        end
+      end
+
+      context "with an invalid Add schema" do
+        it "should raise an error" do
+          hash = { "Email" => "Joe Bloggs" }
+          expect { XpmRuby::Schema::Client::Add[hash] }.to raise_error(Dry::Types::ConstraintError, /Name is missing in Hash input/)
+        end
+
+        it "should raise an error on contacts" do
+          hash = { "Name" => "Joe Bloggs Consulting", "Contacts" => [{ "Contact" => { "Email" => "Joe Bloggs" } }] }
+          expect { XpmRuby::Schema::Client::Add[hash] }.to raise_error(Dry::Types::ConstraintError, /Name is missing in Hash input/)
+        end
+      end
+    end
+  end
+end

--- a/spec/xpm_ruby/schema/job/add_spec.rb
+++ b/spec/xpm_ruby/schema/job/add_spec.rb
@@ -12,7 +12,7 @@ module XpmRuby
         it "should coerce the types" do
           hash = { "Name" => "Joe Bloggs", "Description" => "New Job", "ClientID" => 1234, "StartDate" => 20091023, "DueDate" => 20091023 }
           add = Job::Add[hash]
-          expect(add["ClientID"]).to eql("1234")
+          expect(add[:ClientID]).to eql("1234")
         end
       end
 


### PR DESCRIPTION
Unfortunately I found that when you use String keys on a dry types hash schema, you can't specify optional parameters (it just ignores them). The DSL needs to be defined with symbols so you can put the (`?`) at the end to make it optional.

You can however use `with_key_transform(&:to_sym)` option at the end which will convert your string keys to symbols automatically.

I updated the old job schema as well to reflect what I found with the client schema.

Even thought the keys are converted to symbols, when you export them to XML they are converted back to strings in any case (`:ClientID` becomes `<ClientID></ClientID>`).

if there are missing attributes we now raise a Dry::Types::ConstraintError which will need to be handled in whomever is using this gem.