### PR TITLE
Add RateLimitExceeded error class and raise them when we receive 429 response from XPM API

### DIFF
--- a/lib/xpm_ruby.rb
+++ b/lib/xpm_ruby.rb
@@ -3,6 +3,7 @@ module XpmRuby
   class Unauthorized < Error; end
   class AccessTokenExpired < Unauthorized; end
   class Forbidden < Error; end
+  class RateLimitExceeded < Error; end
 end
 
 require "active_support"

--- a/lib/xpm_ruby/connection.rb
+++ b/lib/xpm_ruby/connection.rb
@@ -58,6 +58,8 @@ module XpmRuby
       when 403 # this can happen with a bad xero_tenant_id
         detail = JSON.parse(response.body)["Detail"]
         raise Forbidden.new(detail)
+      when 429 # rate limit exceeded
+        raise RateLimitExceeded
       when 200
         xml = Ox.load(response.body, mode: :hash_no_attrs, symbolize_keys: false)
 


### PR DESCRIPTION
**Intent (What)**

XPM API V3 now has a rate limit of 60 calls per minute or 5000 class per day. This PR adds `RateLimitExceeded` exception class and make sure we raise it when we receive `429` HTTP status code from XPM API.