### PR TITLE
Ensure that Staff#list and Template#list return an Array

### DIFF
--- a/lib/xpm_ruby/staff.rb
+++ b/lib/xpm_ruby/staff.rb
@@ -11,7 +11,7 @@ module XpmRuby
         .new(access_token: access_token, xero_tenant_id: xero_tenant_id)
         .get(endpoint: "staff.api/list")
 
-      response["StaffList"]["Staff"]
+      Array.wrap(response["StaffList"]["Staff"])
     end
   end
 end

--- a/lib/xpm_ruby/template.rb
+++ b/lib/xpm_ruby/template.rb
@@ -11,7 +11,7 @@ module XpmRuby
         .new(access_token: access_token, xero_tenant_id: xero_tenant_id)
         .get(endpoint: "template.api/list")
 
-      response["Templates"]["Template"]
+      Array.wrap(response["Templates"]["Template"])
     end
   end
 end

--- a/spec/vcr_cassettes/xpm_ruby/staff/list/access_token_accepted_one_staff.yml
+++ b/spec/vcr_cassettes/xpm_ruby/staff/list/access_token_accepted_one_staff.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.xero.com/practicemanager/3.0/staff.api/list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IjFDQUY4RTY2NzcyRDZEQzAyOEQ2NzI2RkQwMjYxNTgxNTcwRUZDMTkiLCJ0eXAiOiJKV1QiLCJ4NXQiOiJISy1PWm5jdGJjQW8xbkp2MENZVmdWY09fQmsifQ.eyJuYmYiOjE1ODgxMTc2NDQsImV4cCI6MTU4ODExOTQ0NCwiaXNzIjoiaHR0cHM6Ly9pZGVudGl0eS54ZXJvLmNvbSIsImF1ZCI6Imh0dHBzOi8vaWRlbnRpdHkueGVyby5jb20vcmVzb3VyY2VzIiwiY2xpZW50X2lkIjoiNDkyMjZBNjIzMzY0NDVFM0FGQUM5QTQ4MkJGOUUyN0UiLCJzdWIiOiIwY2FmMWU4MWYyZWE1MzdkYWIxYjYzNTY3NTc2ZDk3ZSIsImF1dGhfdGltZSI6MTU4ODA1MTE0MywieGVyb191c2VyaWQiOiJmYzI5MDBjNy0wNjcyLTQzOGItOTNkMS1hOGMyNTBmZDg5MjkiLCJnbG9iYWxfc2Vzc2lvbl9pZCI6IjQzMGI0ZmVmMWI0NjQ2MGZiMTgwOWNmNmQ5OWJhODIxIiwianRpIjoiMmI3NGQxZDZhMzcxNDlhN2VjNjkwNmM2NGM0MDFlMjEiLCJzY29wZSI6WyJlbWFpbCIsInByb2ZpbGUiLCJvcGVuaWQiLCJwcmFjdGljZW1hbmFnZXIiLCJvZmZsaW5lX2FjY2VzcyJdfQ.HhzdzozbWidNt8ugO43wPpJhh1H_52khXAxzfwiyXn4r9eBO2qFrYNbVHliDzQrWNurTWnnWttWomCOjfaXpJ0h5m85r6H2h0_nUvd6OnNDEl6yD5Lfqfk1TxbxkEOu2UlJq8pFgeq4dLP9QUpjmJG2cff4bGu809uGDO-lARX1MhZOCUzVCJWdOClZlPivu-zwp8vMDItGCrt-HY8v874X8PNhqiX9aSwZIRzuyNfd71ok0VbGvLeoAxkY-Ph4NdAs-Gvn21S_6-9dIPohtxthqPxDJA3FOJBbQ_OL4y35EkaN3IlNp8J3WILIbjz541OHFCd6nBPGHuByGNMZslg
+      xero-tenant-id:
+      - '0791dc22-8611-4c1c-8df7-1c5453d0795b'
+      content_type:
+      - application/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - text/xml; charset=utf-8
+      server:
+      - Kestrel
+      x-daylimit-remaining:
+      - '4994'
+      x-minlimit-remaining:
+      - '59'
+      xero-correlation-id:
+      - e4487879-7b32-4ecf-b340-4483c145be02
+      content-length:
+      - '1794'
+      expires:
+      - Tue, 28 Apr 2020 23:48:01 GMT
+      cache-control:
+      - max-age=0, no-cache, no-store
+      pragma:
+      - no-cache
+      date:
+      - Tue, 28 Apr 2020 23:48:01 GMT
+      connection:
+      - keep-alive
+      x-client-tls-ver:
+      - tls1.3
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><Response api-method="List"><Status>OK</Status><StaffList><Staff><ID>859230</ID><Name>Adam Silver</Name><Email>dev@practiceignition.com</Email><Phone /><Mobile /><Address /><PayrollCode /></Staff></StaffList></Response>
+    http_version: null
+  recorded_at: Tue, 28 Apr 2020 23:48:01 GMT
+recorded_with: VCR 5.1.0

--- a/spec/xpm_ruby/staff_spec.rb
+++ b/spec/xpm_ruby/staff_spec.rb
@@ -34,15 +34,28 @@ module XpmRuby
       context "when access token accepted" do
         let(:access_token) { "accepted" }
 
-        it "lists staff" do
-          VCR.use_cassette("xpm_ruby/staff/list/access_token_accepted") do
-            staff_list = Staff.list(access_token: access_token, xero_tenant_id: xero_tenant_id)
+        context "when multiple Staff returned" do
+          it "lists staff", :aggregate_failure do
+            VCR.use_cassette("xpm_ruby/staff/list/access_token_accepted") do
+              staff_list = Staff.list(access_token: access_token, xero_tenant_id: xero_tenant_id)
 
-            staff = staff_list.last
+              staff = staff_list.last
 
-            expect(staff["Name"]).to eql("test")
-            expect(staff["Email"]).to eql("adammikulas@gmail.com")
-            # expect(staff.uuid).to eql("1cc99c1e-8cf7-4248-ab84-3e11126facbc")
+              expect(staff["Name"]).to eql("test")
+              expect(staff["Email"]).to eql("adammikulas@gmail.com")
+              # expect(staff.uuid).to eql("1cc99c1e-8cf7-4248-ab84-3e11126facbc")
+            end
+          end
+        end
+
+        context "when a single Staff is returned" do
+          it "returns an Array of Staff", :aggregate_failure do
+            VCR.use_cassette("xpm_ruby/staff/list/access_token_accepted_one_staff") do
+              staff_list = Staff.list(access_token: access_token, xero_tenant_id: xero_tenant_id)
+
+              expect(staff_list).to be_a(Array)
+              expect(staff_list.first["Name"]).to eql("Adam Silver")
+            end
           end
         end
       end


### PR DESCRIPTION
**Intent (What)**

In case if XPM respond contain only 1 element (`Staff.list` and `Template.list`) the gem will return a hash. 

**Motivation (Why)**

Expected behaviour for `list` methods is to always return an Array

**Implementation (How)**

`Array.wrap` makes sure that an array is returned

```
Array.wrap({a: 1, b: 2}) # => [{a: 1, b: 2}]
Array.wrap([1, 2, 3]) # => [1, 2, 3]
```

**Consequence**
