### PR TITLE
Allow the base url to be overridden to query workflowmax

### DIFF
--- a/lib/xpm_ruby/client.rb
+++ b/lib/xpm_ruby/client.rb
@@ -22,9 +22,9 @@ module XpmRuby
       response["Client"]
     end
 
-    def list(access_token:, xero_tenant_id:, detailed: true, modified_since: nil)
+    def list(access_token:, xero_tenant_id:, detailed: true, modified_since: nil, url: nil)
       response = Connection
-        .new(access_token: access_token, xero_tenant_id: xero_tenant_id)
+        .new(access_token: access_token, xero_tenant_id: xero_tenant_id, url: url)
         .get(
           endpoint: "client.api/list",
           params: {

--- a/lib/xpm_ruby/connection.rb
+++ b/lib/xpm_ruby/connection.rb
@@ -3,11 +3,12 @@ require "base64"
 
 module XpmRuby
   class Connection
-    attr_accessor :xero_tenant_id, :authorization
+    attr_accessor :xero_tenant_id, :authorization, :url
 
-    def initialize(access_token:, xero_tenant_id:)
+    def initialize(access_token:, xero_tenant_id:, url: nil)
       @xero_tenant_id = xero_tenant_id
       @authorization = "Bearer " + access_token
+      @url = url || xpm_url
     end
 
     def get(endpoint:, params: nil)
@@ -40,7 +41,7 @@ module XpmRuby
       { "Authorization" => @authorization, "xero-tenant-id" => @xero_tenant_id, "content_type" => "application/xml" }
     end
 
-    def url
+    def xpm_url
       "https://api.xero.com/practicemanager/3.0/"
     end
 

--- a/lib/xpm_ruby/staff.rb
+++ b/lib/xpm_ruby/staff.rb
@@ -6,9 +6,9 @@ module XpmRuby
 
     class Error < Error; end
 
-    def list(access_token:, xero_tenant_id:)
+    def list(access_token:, xero_tenant_id:, url: nil)
       response = Connection
-        .new(access_token: access_token, xero_tenant_id: xero_tenant_id)
+        .new(access_token: access_token, xero_tenant_id: xero_tenant_id, url: url)
         .get(endpoint: "staff.api/list")
 
       Array.wrap(response["StaffList"]["Staff"])


### PR DESCRIPTION
**Intent (What)**
* Changed two queries used for XPM sync, staff list and client list, to accept a url override for the base url

**Motivation (Why)**
* We are temporarily supporting WFM sync with oauth2 via a feature flag - the APIs are the same but the base url is different

**Implementation (How)**
* The list methods take an extra parameter with a nil default, passed to the connection initialiser

**Consequence**
* WFM sync can pass in a url to have WFM queried rather than XPM
* If no url is provided, everything behaves as it used to. This way, no other changes are needed inside the gem or to other callers of the methods