### PR TITLE
[NOJIRA] fix when API doesn't return an array for list methods

### DIFF
--- a/lib/xpm_ruby/category.rb
+++ b/lib/xpm_ruby/category.rb
@@ -9,7 +9,7 @@ module XpmRuby
         .new(access_token: access_token, xero_tenant_id: xero_tenant_id)
         .get(endpoint: "category.api/list")
 
-      Array.wrap(response["Categories"]["Category"])
+      Array.wrap(response.dig("Categories", "Category"))
     end
   end
 end

--- a/lib/xpm_ruby/client.rb
+++ b/lib/xpm_ruby/client.rb
@@ -31,7 +31,7 @@ module XpmRuby
             "detailed" => detailed,
             "modifiedsince" => modified_since }.compact)
 
-      response["Clients"]["Client"]
+      Array.wrap(response.dig("Clients", "Client"))
     end
   end
 end

--- a/lib/xpm_ruby/staff.rb
+++ b/lib/xpm_ruby/staff.rb
@@ -11,7 +11,7 @@ module XpmRuby
         .new(access_token: access_token, xero_tenant_id: xero_tenant_id, url: url)
         .get(endpoint: "staff.api/list")
 
-      Array.wrap(response["StaffList"]["Staff"])
+      Array.wrap(response.dig("StaffList", "Staff"))
     end
   end
 end

--- a/lib/xpm_ruby/template.rb
+++ b/lib/xpm_ruby/template.rb
@@ -11,7 +11,7 @@ module XpmRuby
         .new(access_token: access_token, xero_tenant_id: xero_tenant_id)
         .get(endpoint: "template.api/list")
 
-      Array.wrap(response["Templates"]["Template"])
+      Array.wrap(response.dig("Templates", "Template"))
     end
   end
 end

--- a/spec/vcr_cassettes/xpm_ruby/category/list_empty_array.yml
+++ b/spec/vcr_cassettes/xpm_ruby/category/list_empty_array.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.xero.com/practicemanager/3.0/category.api/list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Authorization:
+      - Bearer access_token
+      xero-tenant-id:
+      - '0791dc22-8611-4c1c-8df7-1c5453d0795b'
+      content_type:
+      - application/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - text/xml; charset=utf-8
+      content-length:
+      - '258'
+      server:
+      - nginx
+      xero-correlation-id:
+      - c736aae5-0038-4fec-a83d-915bbb5645d9
+      x-appminlimit-remaining:
+      - '9999'
+      x-minlimit-remaining:
+      - '59'
+      x-daylimit-remaining:
+      - '4992'
+      expires:
+      - Sun, 07 Mar 2021 22:41:49 GMT
+      cache-control:
+      - max-age=0, no-cache, no-store
+      pragma:
+      - no-cache
+      date:
+      - Sun, 07 Mar 2021 22:41:49 GMT
+      connection:
+      - keep-alive
+      x-client-tls-ver:
+      - tls1.3
+    body:
+      encoding: UTF-8
+      string: <Response api-method="List"><Status>OK</Status><Categories /></Response>
+    http_version: null
+  recorded_at: Sun, 07 Mar 2021 22:41:49 GMT
+recorded_with: VCR 5.1.0

--- a/spec/xpm_ruby/category_spec.rb
+++ b/spec/xpm_ruby/category_spec.rb
@@ -8,21 +8,37 @@ module XpmRuby
       let(:xero_tenant_id) { "0791dc22-8611-4c1c-8df7-1c5453d0795b" }
       let(:access_token) { "access_token" }
 
-      around(:each) do |example|
-        VCR.use_cassette("xpm_ruby/category/list") do
-          example.run
+      context "when API returns an array of categories" do
+        around(:each) do |example|
+          VCR.use_cassette("xpm_ruby/category/list") do
+            example.run
+          end
+        end
+
+        it "lists categories" do
+          categories_list = service.list(access_token: access_token, xero_tenant_id: xero_tenant_id)
+
+          expect(categories_list.length).to eq(3)
+
+          category = categories_list.first
+
+          expect(category["Name"]).to eql("Compliance")
+          expect(category["ID"]).to eql("304252")
         end
       end
 
-      it "lists categories" do
-        categories_list = service.list(access_token: access_token, xero_tenant_id: xero_tenant_id)
+      context "when API doesn't return an array" do
+        around(:each) do |example|
+          VCR.use_cassette("xpm_ruby/category/list_empty_array") do
+            example.run
+          end
+        end
 
-        expect(categories_list.length).to eq(3)
+        it "returns an empty array" do
+          categories_list = service.list(access_token: access_token, xero_tenant_id: xero_tenant_id)
 
-        category = categories_list.first
-
-        expect(category["Name"]).to eql("Compliance")
-        expect(category["ID"]).to eql("304252")
+          expect(categories_list).to eq([])
+        end
       end
     end
   end

--- a/spec/xpm_ruby/client_spec.rb
+++ b/spec/xpm_ruby/client_spec.rb
@@ -59,10 +59,14 @@ module XpmRuby
 
         it "list clients modified since" do
           VCR.use_cassette("xpm_ruby/client/list/when_modified_since") do
-            client = Client.list(
+            clients_list = Client.list(
               access_token: access_token,
               xero_tenant_id: xero_tenant_id,
               modified_since: modified_since)
+
+            expect(clients_list.size).to eq(1)
+
+            client = clients_list.first
 
             expect(client["ID"]).to eq("25655881")
           end


### PR DESCRIPTION
**Intent (What)**

Sometimes in response for list methods XPM doesn't return a "second-level key". For example, we expect the XML response to have structure `Categories -> Category -> content` but we receive just `Categories`.

A real life example of such response: 

```
<Response api-method="List"><Status>OK</Status><Categories /></Response>
```

I assume it can happen not just with categories but other methods.

**Motivation (Why)**

gem fails with https://sentry.io/organizations/ignition/issues/2260233094/?project=1314270&referrer=slack

**Implementation (How)**

**Consequence**
