### PR TITLE
Allow creating job with no description

### DIFF
--- a/lib/xpm_ruby/schema/job/add.rb
+++ b/lib/xpm_ruby/schema/job/add.rb
@@ -5,7 +5,7 @@ module XpmRuby
     module Job
       Add = Types::Hash.schema(
         Name: Types::String,
-        Description: Types::String,
+        Description: Types::String.optional,
         ClientID: Types::Coercible::String,
         ContactID?: Types::Coercible::String,
         StartDate: Types::Coercible::String,


### PR DESCRIPTION
Description doesn't appear to be required by Xpm, but our schema validation is validating that it's not nil or empty.