### PR TITLE
Add ConnectionTimeout error exception and raise when we get Faraday::TimeoutError exception

### DIFF
--- a/lib/xpm_ruby.rb
+++ b/lib/xpm_ruby.rb
@@ -4,6 +4,7 @@ module XpmRuby
   class AccessTokenExpired < Unauthorized; end
   class Forbidden < Error; end
   class ConnectionFailed < Error; end
+  class ConnectionTimeout < Error; end
   class RateLimitExceeded < Error
     attr_reader :details
 

--- a/lib/xpm_ruby/connection.rb
+++ b/lib/xpm_ruby/connection.rb
@@ -17,6 +17,8 @@ module XpmRuby
       handle_response(response)
     rescue Faraday::ConnectionFailed => error
       raise ConnectionFailed.new(error.message)
+    rescue Faraday::TimeoutError => error
+      raise ConnectionTimeout.new(error.message)
     end
 
     def post(endpoint:, data:)
@@ -25,6 +27,8 @@ module XpmRuby
       handle_response(response)
     rescue Faraday::ConnectionFailed => error
       raise ConnectionFailed.new(error.message)
+    rescue Faraday::TimeoutError => error
+      raise ConnectionTimeout.new(error.message)
     end
 
     def put(endpoint:, data:)
@@ -33,6 +37,8 @@ module XpmRuby
       handle_response(response)
     rescue Faraday::ConnectionFailed => error
       raise ConnectionFailed.new(error.message)
+    rescue Faraday::TimeoutError => error
+      raise ConnectionTimeout.new(error.message)
     end
 
     def delete(endpoint:, id:)
@@ -41,6 +47,8 @@ module XpmRuby
       handle_response(response)
     rescue Faraday::ConnectionFailed => error
       raise ConnectionFailed.new(error.message)
+    rescue Faraday::TimeoutError => error
+      raise ConnectionTimeout.new(error.message)
     end
 
     private

--- a/spec/xpm_ruby/connection_spec.rb
+++ b/spec/xpm_ruby/connection_spec.rb
@@ -47,6 +47,17 @@ module XpmRuby
         end
       end
 
+      context "when connection to API timeout" do
+        before(:each) do
+          allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::TimeoutError.new("timeout"))
+        end
+
+        it "should raise an error" do
+          connection = Connection.new(access_token: "bad_token", xero_tenant_id: xero_tenant_id)
+          expect { connection.get(endpoint: "staff.api/list") }.to raise_error(XpmRuby::ConnectionTimeout)
+        end
+      end
+
       context "when API rate limit is exceeded" do
         it "should raise an error with details" do
           VCR.use_cassette("xpm_ruby/connection/get/rate_limit_exceeded") do


### PR DESCRIPTION
**Intent (What)**

This PR adds a new error class `ConnectionTimeout` to the XPM ruby gem. We will raise this exception when we get Faraday::TimeoutError exception when sending request to XPM API.

This way we don't leak the abstraction and make sure the main app only aware of `XpmRuby` error classes not the library underneath it.

**Motivation (Why)**

I was investigating an error with Workflow job stuck in deploying yesterday. I discovered that the reason why the job was stuck in deploying is because we get timeout error when trying to create the job in XPM.

The plan is to merge this PR and add a logic to requeue the deploy job to XPM sidekiq job if we get the timeout error.