### PR TITLE
Fix contacts array when creating or updating client

### DIFF
--- a/lib/xpm_ruby/schema/client/add.rb
+++ b/lib/xpm_ruby/schema/client/add.rb
@@ -25,16 +25,14 @@ module XpmRuby
         AccountManagerID?: Types::String,
         Contacts?: Types::Array.of(
           Types::Hash.schema(
-            Contact: Types::Hash.schema(
-              Name: Types::String,
-              IsPrimary?: Types::String,
-              Salutation?: Types::String,
-              Addressee?: Types::String,
-              Phone?: Types::Coercible::String,
-              Mobile?: Types::Coercible::String,
-              Email?: Types::String,
-              Position?: Types::String
-            ).with_key_transform(&:to_sym)
+            Name: Types::String,
+            IsPrimary?: Types::String,
+            Salutation?: Types::String,
+            Addressee?: Types::String,
+            Phone?: Types::Coercible::String,
+            Mobile?: Types::Coercible::String,
+            Email?: Types::String,
+            Position?: Types::String
           ).with_key_transform(&:to_sym)
         ),
         BillingClientID?: Types::Coercible::String,

--- a/lib/xpm_ruby/schema/client/update.rb
+++ b/lib/xpm_ruby/schema/client/update.rb
@@ -26,16 +26,14 @@ module XpmRuby
         AccountManagerID?: Types::String,
         Contacts?: Types::Array.of(
           Types::Hash.schema(
-            Contact: Types::Hash.schema(
-              Name: Types::String,
-              IsPrimary?: Types::String,
-              Salutation?: Types::String,
-              Addressee?: Types::String,
-              Phone?: Types::Coercible::String,
-              Mobile?: Types::Coercible::String,
-              Email?: Types::String,
-              Position?: Types::String
-            ).with_key_transform(&:to_sym)
+            Name: Types::String,
+            IsPrimary?: Types::String,
+            Salutation?: Types::String,
+            Addressee?: Types::String,
+            Phone?: Types::Coercible::String,
+            Mobile?: Types::Coercible::String,
+            Email?: Types::String,
+            Position?: Types::String
           ).with_key_transform(&:to_sym)
         ),
         BillingClientID?: Types::Coercible::String,

--- a/spec/xpm_ruby/schema/client/add_spec.rb
+++ b/spec/xpm_ruby/schema/client/add_spec.rb
@@ -6,7 +6,7 @@ module XpmRuby
       context "with a valid Add schema" do
         context "with contacts" do
           it "should not raise an error" do
-            hash = { "Name" => "Joe Bloggs Consulting", "Contacts" => [{ "Contact" => { "Name" => "Joe Bloggs" } }] }
+            hash = { "Name" => "Joe Bloggs Consulting", "Contacts" => [{ "Name" => "Joe Bloggs" }] }
             expect { Client::Add[hash] }.not_to raise_error
           end
         end
@@ -32,7 +32,7 @@ module XpmRuby
         end
 
         it "should raise an error on contacts" do
-          hash = { "Name" => "Joe Bloggs Consulting", "Contacts" => [{ "Contact" => { "Email" => "Joe Bloggs" } }] }
+          hash = { "Name" => "Joe Bloggs Consulting", "Contacts" => [{ "Email" => "Joe Bloggs" }] }
           expect { Client::Add[hash] }.to raise_error(Dry::Types::SchemaError, /Name is missing in Hash input/)
         end
       end

--- a/spec/xpm_ruby/schema/client/update_spec.rb
+++ b/spec/xpm_ruby/schema/client/update_spec.rb
@@ -6,7 +6,7 @@ module XpmRuby
       context "with a valid Update schema" do
         context "with contacts" do
           it "should not raise an error" do
-            hash = { "ID" => 25655881, "Name" => "Joe Bloggs Consulting", "Contacts" => [{ "Contact" => { "Name" => "Joe Bloggs" } }] }
+            hash = { "ID" => 25655881, "Name" => "Joe Bloggs Consulting", "Contacts" => [{ "Name" => "Joe Bloggs" }] }
             expect { Client::Update[hash] }.not_to raise_error
           end
         end
@@ -32,7 +32,7 @@ module XpmRuby
         end
 
         it "should raise an error on contacts" do
-          hash = { "ID" => 25655881, "Name" => "Joe Bloggs Consulting", "Contacts" => [{ "Contact" => { "Email" => "Joe Bloggs" } }] }
+          hash = { "ID" => 25655881, "Name" => "Joe Bloggs Consulting", "Contacts" => [{ "Email" => "Joe Bloggs" }] }
           expect { Client::Update[hash] }.to raise_error(Dry::Types::SchemaError, /Name is missing in Hash input/)
         end
       end


### PR DESCRIPTION
The XPM API expects xml of the form
```
  <Contacts>
    <Contact>
      <Name>Jo Bloggs</Name>
```
inside a Client for creating contacts when updating.  The code appeared to specify this, but actually `.to_xml` on a Hash works differently to expected, where an array type called `Contacts` will automatically have each entry wrapped with `Contact`.  So the generated XML was looking like
```
<Client>
  <Name>Bob Bobus 2</Name>
  <Email>bob@hotmail.com</Email>
  <Phone></Phone>
  <GSTRegistered></GSTRegistered>
  <JobManagerID>1000237</JobManagerID>
  <Contacts type="array">
    <Contact>
      <Contact>
        <Name>bob bobus</Name>
```

Which meant it didn't work.  This was only for creating contacts during client creation, which I gather nobody had used before.