### PR TITLE
Add specific errors to differentiate them

### DIFF
--- a/lib/xpm_ruby.rb
+++ b/lib/xpm_ruby.rb
@@ -1,6 +1,10 @@
 module XpmRuby
   class Error < StandardError; end
 
+  class ApiError < Error; end
+
+  class UnknownError < Error; end
+
   class Unauthorized < Error; end
 
   class AccessTokenExpired < Unauthorized; end

--- a/lib/xpm_ruby/connection.rb
+++ b/lib/xpm_ruby/connection.rb
@@ -100,10 +100,10 @@ module XpmRuby
         when "OK"
           xml["Response"]
         when "ERROR"
-          raise Error.new(xml["Response"]["ErrorDescription"])
+          raise ApiError.new(xml["Response"]["ErrorDescription"])
         end
       else
-        raise Error.new(response.status)
+        raise UnknownError.new(response.status)
       end
     end
   end

--- a/lib/xpm_ruby/version.rb
+++ b/lib/xpm_ruby/version.rb
@@ -1,3 +1,3 @@
 module XpmRuby
-  VERSION = "0.1.0".freeze
+  VERSION = "0.2.0".freeze
 end


### PR DESCRIPTION
Currently any error parsed from XPM is an instance of the base class `XpmRuby::Error`, which means you can't specifically rescue these errors separately to other errors.  This is a problem if say, you want to catch error in validating data from XPM but not catch other things like TokenExpired (because it's handled elsewhere).

This change adds two new error classes to differentiate these errors.  They still inherit from the same parent as before so it should be a non breaking change.  I bumped the version too because I guess technically that's what we should do.