### PR TITLE
[RB-326] v31 client updates

### DIFF
--- a/lib/xpm_ruby/connection.rb
+++ b/lib/xpm_ruby/connection.rb
@@ -39,8 +39,9 @@ module XpmRuby
       raise ConnectionTimeout.new(error.message)
     end
 
-    def delete(endpoint:, id:)
-      response = build_connection(url: url).delete("#{endpoint}/#{id}", nil, headers)
+    def delete(endpoint:, id:, params: {})
+      query_string = CGI.unescape(params.to_query)
+      response = build_connection(url: url).delete("#{endpoint}/#{id}?#{query_string}", nil, headers)
       handle_response(response)
     rescue Faraday::ConnectionFailed => error
       raise ConnectionFailed.new(error.message)

--- a/lib/xpm_ruby/contact.rb
+++ b/lib/xpm_ruby/contact.rb
@@ -24,10 +24,12 @@ module XpmRuby
       response["Contact"]
     end
 
-    def delete(access_token:, xero_tenant_id:, contact_id:)
+    def delete(access_token:, xero_tenant_id:, contact_id:, client_id: nil)
+      request_params = { client_id: client_id }.compact
+
       response = Connection
         .new(access_token: access_token, xero_tenant_id: xero_tenant_id)
-        .delete(endpoint: "client.api/contact", id: contact_id)
+        .delete(endpoint: "client.api/contact", id: contact_id, params: request_params)
 
       response["Contact"]
     end

--- a/lib/xpm_ruby/schema/contact/update.rb
+++ b/lib/xpm_ruby/schema/contact/update.rb
@@ -4,6 +4,9 @@ module XpmRuby
   module Schema
     module Contact
       Update = Types::Hash.schema(
+        Client?: Types::Hash.schema(
+          ID: Types::Coercible::String
+        ).with_key_transform(&:to_sym),
         Name?: Types::String,
         IsPrimary?: Types::String,
         Salutation?: Types::String,

--- a/lib/xpm_ruby/version.rb
+++ b/lib/xpm_ruby/version.rb
@@ -1,3 +1,3 @@
 module XpmRuby
-  VERSION = "0.3.0".freeze
+  VERSION = "0.4.0".freeze
 end

--- a/spec/vcr_cassettes/xpm_ruby/contact/delete.yml
+++ b/spec/vcr_cassettes/xpm_ruby/contact/delete.yml
@@ -50,6 +50,56 @@ http_interactions:
       encoding: UTF-8
       string: <Response api-method="Contact"><Status>OK</Status><Contact><ID>14574323</ID><Name>some
         guy person</Name><Mobile></Mobile><Email></Email><Phone></Phone><Position></Position><Salutation></Salutation><Addressee></Addressee><IsPrimary>No</IsPrimary></Contact></Response>
-    http_version: null
   recorded_at: Mon, 04 May 2020 05:10:25 GMT
-recorded_with: VCR 5.1.0
+- request:
+    method: delete
+    uri: https://api.xero.com/practicemanager/3.0/client.api/contact/14574323?client_id=25655881
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.4
+      Authorization:
+      - Bearer token
+      xero-tenant-id:
+      - '0791dc22-8611-4c1c-8df7-1c5453d0795b'
+      content_type:
+      - application/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - text/xml; charset=utf-8
+      server:
+      - Kestrel
+      x-appminlimit-remaining:
+      - '9999'
+      x-daylimit-remaining:
+      - '4983'
+      x-minlimit-remaining:
+      - '59'
+      xero-correlation-id:
+      - fc3f4eb9-a9e0-456c-8c02-28e9f5aec8c5
+      content-length:
+      - '266'
+      expires:
+      - Fri, 14 Apr 2023 11:36:53 GMT
+      cache-control:
+      - max-age=0, no-cache, no-store
+      pragma:
+      - no-cache
+      date:
+      - Mon, 04 May 2020 05:10:25 GMT
+      connection:
+      - keep-alive
+      x-client-tls-ver:
+      - tls1.3
+    body:
+      encoding: UTF-8
+      string: <Response api-method="Contact"><Status>OK</Status><Contact><ID>14574323</ID><Name>some
+        guy person</Name><Mobile></Mobile><Email></Email><Phone></Phone><Position></Position><Salutation></Salutation><Addressee></Addressee><IsPrimary>No</IsPrimary></Contact></Response>
+  recorded_at: Fri, 14 Apr 2023 11:36:53 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr_cassettes/xpm_ruby/contact/update.yml
+++ b/spec/vcr_cassettes/xpm_ruby/contact/update.yml
@@ -58,4 +58,65 @@ http_interactions:
         Pty Ltd Updated 3</Name><Mobile></Mobile><Email></Email><Phone></Phone><Position></Position><Salutation></Salutation><Addressee></Addressee><IsPrimary>No</IsPrimary></Contact></Response>
     http_version: null
   recorded_at: Tue, 05 May 2020 04:33:24 GMT
+- request:
+    method: put
+    uri: https://api.xero.com/practicemanager/3.0/client.api/contact/15412877
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Contact>
+          <Client>
+            <ID>25655881</ID>
+          </Client>
+          <Name>Acmer Pty Ltd Updated 3</Name>
+        </Contact>
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Authorization:
+      - Bearer token
+      xero-tenant-id:
+      - '0791dc22-8611-4c1c-8df7-1c5453d0795b'
+      content_type:
+      - application/xml
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - text/xml; charset=utf-8
+      server:
+      - Kestrel
+      x-appminlimit-remaining:
+      - '9999'
+      x-daylimit-remaining:
+      - '4985'
+      x-minlimit-remaining:
+      - '59'
+      xero-correlation-id:
+      - 1905d74e-32f4-49db-874e-91e08c9938e0
+      content-length:
+      - '274'
+      expires:
+      - Tue, 05 May 2020 04:33:24 GMT
+      cache-control:
+      - max-age=0, no-cache, no-store
+      pragma:
+      - no-cache
+      date:
+      - Tue, 05 May 2020 04:33:24 GMT
+      connection:
+      - keep-alive
+      x-client-tls-ver:
+      - tls1.3
+    body:
+      encoding: UTF-8
+      string: <Response api-method="Contact"><Status>OK</Status><Contact><ID>15412877</ID><Name>Acmer
+        Pty Ltd Updated 3</Name><Mobile></Mobile><Email></Email><Phone></Phone><Position></Position><Salutation></Salutation><Addressee></Addressee><IsPrimary>No</IsPrimary></Contact></Response>
+    http_version: null
+  recorded_at: Thu, 13 Apr 2023 05:18:03 GMT
 recorded_with: VCR 5.1.0

--- a/spec/xpm_ruby/contact_spec.rb
+++ b/spec/xpm_ruby/contact_spec.rb
@@ -80,15 +80,32 @@ module XpmRuby
       let(:access_token) { "token" }
       let(:contact_id) { "14574323" }
 
-      it "deletes the contact" do
-        VCR.use_cassette("xpm_ruby/contact/delete") do
-          deleted_contact = Contact.delete(
-            access_token: access_token,
-            xero_tenant_id: xero_tenant_id,
-            contact_id: contact_id)
+      context "without Client ID" do
+        it "deletes the contact" do
+          VCR.use_cassette("xpm_ruby/contact/delete") do
+            deleted_contact = Contact.delete(
+              access_token: access_token,
+              xero_tenant_id: xero_tenant_id,
+              contact_id: contact_id)
 
-          expect(deleted_contact["ID"]).to eql(contact_id)
-          expect(deleted_contact["Name"]).to eql("some guy person")
+            expect(deleted_contact["ID"]).to eql(contact_id)
+            expect(deleted_contact["Name"]).to eql("some guy person")
+          end
+        end
+      end
+
+      context "with Client ID" do
+        it "deletes the contact" do
+          VCR.use_cassette("xpm_ruby/contact/delete") do
+            deleted_contact = Contact.delete(
+              access_token: access_token,
+              xero_tenant_id: xero_tenant_id,
+              contact_id: contact_id,
+              client_id: 25655881)
+
+            expect(deleted_contact["ID"]).to eql(contact_id)
+            expect(deleted_contact["Name"]).to eql("some guy person")
+          end
         end
       end
     end

--- a/spec/xpm_ruby/contact_spec.rb
+++ b/spec/xpm_ruby/contact_spec.rb
@@ -30,7 +30,6 @@ module XpmRuby
       let(:xero_tenant_id) { "0791dc22-8611-4c1c-8df7-1c5453d0795b" }
       let(:access_token) { "token" }
 
-      
       context "without Client ID" do
         let(:contact) do
           {

--- a/spec/xpm_ruby/contact_spec.rb
+++ b/spec/xpm_ruby/contact_spec.rb
@@ -30,22 +30,47 @@ module XpmRuby
       let(:xero_tenant_id) { "0791dc22-8611-4c1c-8df7-1c5453d0795b" }
       let(:access_token) { "token" }
 
-      let(:contact) do
-        {
-          "Name" => "Acmer Pty Ltd Updated 3"
-        }
+      
+      context "without Client ID" do
+        let(:contact) do
+          {
+            "Name" => "Acmer Pty Ltd Updated 3"
+          }
+        end
+
+        it "updates contact" do
+          VCR.use_cassette("xpm_ruby/contact/update") do
+            updated_contact = Contact.update(
+              access_token: access_token,
+              xero_tenant_id: xero_tenant_id,
+              id: 15412877,
+              contact: contact)
+
+            expect(updated_contact["ID"]).not_to be_nil
+            expect(updated_contact["Name"]).to eql(updated_contact["Name"])
+          end
+        end
       end
 
-      it "updates contact" do
-        VCR.use_cassette("xpm_ruby/contact/update") do
-          updated_contact = Contact.update(
-            access_token: access_token,
-            xero_tenant_id: xero_tenant_id,
-            id: 15412877,
-            contact: contact)
+      context "with Client ID" do
+        let(:contact) do
+          {
+            "Client" => { "ID" => 25655881 },
+            "Name" => "Acmer Pty Ltd Updated 3"
+          }
+        end
 
-          expect(updated_contact["ID"]).not_to be_nil
-          expect(updated_contact["Name"]).to eql(updated_contact["Name"])
+        it "updates contact" do
+          VCR.use_cassette("xpm_ruby/contact/update") do
+            updated_contact = Contact.update(
+              access_token: access_token,
+              xero_tenant_id: xero_tenant_id,
+              id: 15412877,
+              contact: contact)
+
+            expect(updated_contact["ID"]).not_to be_nil
+            expect(updated_contact["Name"]).to eql(updated_contact["Name"])
+          end
         end
       end
     end

--- a/spec/xpm_ruby/schema/contact/update_spec.rb
+++ b/spec/xpm_ruby/schema/contact/update_spec.rb
@@ -8,6 +8,13 @@ module XpmRuby
           hash = { "Name" => "Joe Bloggs" }
           expect { Contact::Update[hash] }.not_to raise_error
         end
+
+        context "with a client ID" do
+          it "should not raise an error" do
+            hash = { "Client" => { "ID" => "123" }, "Name" => "Joe Bloggs" }
+            expect { Contact::Update[hash] }.not_to raise_error
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
**Intent (What)**

XPM updates their API version to v3.1 and unfortunately it affects the v3.0 as well. 

They're changing the relation between Contact and Client from 1:1 to 1:many. Yes, multiple Clients can share the same contact. We need to do a couple of small changes in order to support that.

**Motivation (Why)**

**Implementation (How)**

1. Update Contact:

API will response with an error If a Contact belongs to multiple Clients so I allow Client ID param for Contact update action.
It's optional. The API will still perform update without Client ID if Contact belongs to 1 Client.

2. Delete Contact:

The same logic applies here. Optional Client ID. Error if Contact belongs to multiple Clients and Client ID is not provided.

**Consequence**

It shouldn't affect any existing users of the gem as Client ID is optional. XPM really should've updated API to v4.0 as it's a non-reversible breaking change
