### PR TITLE
Remove isProspect from client.api schema

### DIFF
--- a/lib/xpm_ruby/schema/client/add.rb
+++ b/lib/xpm_ruby/schema/client/add.rb
@@ -21,7 +21,6 @@ module XpmRuby
         WebSite?: Types::String,
         ReferralSource?: Types::String,
         ExportCode?: Types::String,
-        IsProspect?: Types::String,
         AccountManagerID?: Types::String,
         Contacts?: Types::Array.of(
           Types::Hash.schema(

--- a/lib/xpm_ruby/schema/client/update.rb
+++ b/lib/xpm_ruby/schema/client/update.rb
@@ -22,7 +22,6 @@ module XpmRuby
         WebSite?: Types::String,
         ReferralSource?: Types::String,
         ExportCode?: Types::String,
-        IsProspect?: Types::String,
         AccountManagerID?: Types::String,
         Contacts?: Types::Array.of(
           Types::Hash.schema(


### PR DESCRIPTION
`isProspect` is being deprecated and ignored soon.

* [Practice Manager v3.0 and v3.1 changes document](https://brandfolder.xero.com/8HSCTPAX/at/9s37hf4ghp3kxwpvqw5qj4/practice-manager-api-changes.pdf?utm_source=sfmc&utm_medium=email&utm_campaign=GL3128%20Dev%20API%20NSL&utm_content=August&sfmc_key=47facc685829d2c52ccf7782208ee2b13ce165e2-R0wgMzEyOCBBIEVDTyBBUEkgTlNMIEFQUCBQQVJUTkVSIC0gQXVnIDI0)